### PR TITLE
Option to load more conversations into conversation history.

### DIFF
--- a/frontend/conversation_ui.js
+++ b/frontend/conversation_ui.js
@@ -48,7 +48,13 @@ function setupConversationEventListeners() {
     
     // Refresh conversations
     document.getElementById('refreshConversations').addEventListener('click', async () => {
-        await conversationManager.loadConversations();
+        await conversationManager.loadConversations({ reset: true });
+        displayConversations();
+    });
+
+    // Load more conversations
+    document.getElementById('loadMoreConversations').addEventListener('click', async () => {
+        await conversationManager.loadMoreConversations();
         displayConversations();
     });
 }
@@ -113,6 +119,7 @@ function displayConversations() {
                 <p class="empty-state-subtitle">Start a new conversation to see it here</p>
             </div>
         `;
+        updateLoadMoreState();
         return;
     }
     
@@ -158,6 +165,33 @@ function displayConversations() {
             }
         }
     });
+
+    updateLoadMoreState();
+}
+
+function updateLoadMoreState() {
+    const loadMoreButton = document.getElementById('loadMoreConversations');
+    const countLabel = document.getElementById('conversationCount');
+    if (!loadMoreButton || !countLabel) {
+        return;
+    }
+
+    const loadedCount = conversationManager.getAllConversations().length;
+    const totalCount = conversationManager.getTotalConversations();
+    const hasMore = conversationManager.hasMoreConversations();
+    const isLoading = conversationManager.isLoadingConversations();
+
+    if (totalCount > 0) {
+        countLabel.textContent = `Showing ${loadedCount} of ${totalCount}`;
+    } else if (loadedCount > 0) {
+        countLabel.textContent = `Showing ${loadedCount}`;
+    } else {
+        countLabel.textContent = '';
+    }
+
+    loadMoreButton.style.display = hasMore ? 'inline-flex' : 'none';
+    loadMoreButton.disabled = isLoading;
+    loadMoreButton.textContent = isLoading ? 'Loading...' : 'Load more';
 }
 
 function createConversationItem(conversation) {

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -386,6 +386,10 @@
                     <div class="conversations-list" id="conversationsList">
                         <div class="loading">Loading conversations...</div>
                     </div>
+                    <div class="conversations-footer">
+                        <span id="conversationCount" class="conversation-count"></span>
+                        <button id="loadMoreConversations" class="btn btn-secondary" type="button">Load more</button>
+                    </div>
                 </div>
             </div>
         </div>

--- a/frontend/styles.css
+++ b/frontend/styles.css
@@ -2689,6 +2689,20 @@ pre {
     gap: 0.5rem;
 }
 
+.conversations-footer {
+    display: flex;
+    align-items: center;
+    justify-content: space-between;
+    gap: 1rem;
+    padding-top: 0.5rem;
+    border-top: 1px solid #e0e0e0;
+}
+
+.conversation-count {
+    font-size: 0.875rem;
+    color: #666;
+}
+
 .conversation-item {
     display: flex;
     align-items: center;
@@ -2928,5 +2942,14 @@ pre {
     
     .action-btn .material-icons {
         font-size: 1.1rem !important;
+    }
+
+    .conversations-footer {
+        flex-direction: column;
+        align-items: stretch;
+    }
+
+    .conversation-count {
+        text-align: center;
     }
 }


### PR DESCRIPTION
This adds pagination support to the conversation history UI so users can load more than the default 100 conversations. The frontend now requests conversations in pages, appends results, and shows a footer with count + “Load more” button.

Changes:

Add pagination state and skip/limit support in the conversation manager.
Add “Load more” control and count label in the conversations modal.
Add footer styling and responsive layout tweaks.

Testing:
--Local host (1/21/2026)
--Production host (1/21/2026; changes are live)