### PR TITLE
fix build and push update for retrieving microsandbox image

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -160,17 +160,23 @@ jobs:
             echo "==> Deployed commit:"
             git --no-pager log -1 --oneline
 
-            echo "==> Logging in to ghcr.io (ephemeral, run-scoped token) to pull the private image"
+            echo "==> Logging in to ghcr.io (ephemeral, run-scoped token) to pull the private image(s)"
             echo "${{ secrets.GITHUB_TOKEN }}" | docker login ghcr.io -u "${{ github.actor }}" --password-stdin
 
             echo "==> Pulling image tag ${IMAGE_TAG}"
             IMAGE_TAG="${IMAGE_TAG}" docker compose pull web
 
-            # Remove the credential from the VM right away; the token also expires when the run ends.
-            docker logout ghcr.io
-
             echo "==> Running: ${DEPLOY_CMD}"
+            # Login stays active through DEPLOY_CMD (not just the `web` pull
+            # above) - DEPLOY_CMD's own `docker compose up` also needs to
+            # pull other private ghcr.io images (e.g. `openwebui` -
+            # ghcr.io/uhsealevelcenter/idea-open-webui). Logging out before
+            # this ran used to break that pull with "unauthorized".
             IMAGE_TAG="${IMAGE_TAG}" bash -c "${DEPLOY_CMD}"
+
+            # Remove the credential from the VM now that all pulls are done;
+            # the token also expires when the run ends regardless.
+            docker logout ghcr.io
           REMOTE
 
       - name: Smoke check

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -139,12 +139,21 @@ services:
       # "auto" | "microsandbox" | "local" - see sandbox_service/terminal_registry.py
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-auto}
       # OCI image booted for each new microsandbox VM - see msb_sandbox.py.
-      # Set to a published build of interpreter_kernel/ (e.g.
-      # idea/oi-kernel:slim) to give sandboxes the persistent Python kernel
-      # (run_python_tool) and Open Terminal-backed grep_search_tool/
-      # glob_search_tool; defaults to the bare "python" image, which only
-      # supports run_terminal_tool/write_file_tool.
-      - SANDBOX_IMAGE=${SANDBOX_IMAGE:-python}
+      # Published build of interpreter_kernel/ (see that directory's
+      # README for how it's built/pushed) - gives sandboxes the persistent
+      # Python kernel (run_python_tool) and Open Terminal-backed
+      # grep_search_tool/glob_search_tool. Override via .env (SANDBOX_IMAGE)
+      # to pin a different tag/digest, or fall back to the bare "python"
+      # image (only run_terminal_tool/write_file_tool) if needed.
+      - SANDBOX_IMAGE=${SANDBOX_IMAGE:-ghcr.io/uhsealevelcenter/idea-oi-kernel:slim}
+      # Only needed if the ghcr.io package above is private - see
+      # entrypoint.sh and interpreter_kernel/README.md's "Private registry
+      # auth" section for how these configure microsandbox's own pull
+      # credentials (a plain `docker login ghcr.io` doesn't cover this -
+      # msb pulls images itself, independent of the Docker daemon). Leave
+      # both unset if the package is public.
+      - GHCR_USERNAME=${GHCR_USERNAME:-}
+      - GHCR_PAT=${GHCR_PAT:-}
       # Idle sandboxes auto-drain (stop, not delete) after this many seconds
       # of inactivity; empty SANDBOX_MAX_DURATION_SECONDS disables the hard
       # lifetime cap. See sandbox_service/msb_sandbox.py.

--- a/example.env
+++ b/example.env
@@ -71,6 +71,25 @@ INTERNAL_SERVICE_TOKEN=
 # enable microsandbox's isolated microVM backend.
 KVM_DEVICE_PATH=
 
+# OCI image booted for each new microsandbox VM - see
+# sandbox_service/msb_sandbox.py and interpreter_kernel/README.md. Defaults
+# (docker-compose.yml) to ghcr.io/uhsealevelcenter/idea-oi-kernel:slim,
+# which gives sandboxes a persistent Python kernel (run_python_tool) and
+# Open Terminal-backed grep_search_tool/glob_search_tool. Leave unset to
+# use that default, or set to "python" to fall back to the bare image
+# (only run_terminal_tool/write_file_tool).
+SANDBOX_IMAGE=
+
+# Only needed if the ghcr.io package above is private - GitHub username +
+# a Personal Access Token (classic, read:packages scope) so `msb`
+# (microsandbox, running inside the sandbox container) can pull it. This is
+# NOT the same as a `docker login` on the host - see interpreter_kernel/
+# README.md's "Private registry auth" section for why and how
+# sandbox_service/entrypoint.sh uses these. Leave both blank if the
+# package is public.
+GHCR_USERNAME=
+GHCR_PAT=
+
 # ==== LiteLLM proxy (see litellm/) ====
 # Dedicated Postgres role, scoped to its own `litellm` schema on the
 # existing `db` service's idea_db database - kept separate from

--- a/interpreter_kernel/README.md
+++ b/interpreter_kernel/README.md
@@ -74,6 +74,53 @@ of the bare `python` image. `run_terminal_tool`/`write_file_tool` work
 against any image; `run_python_tool`/`grep_search_tool`/`glob_search_tool`
 specifically require this one (or one built on top of it).
 
+## Private registry auth
+
+If this image is pushed to a *private* package (e.g.
+`ghcr.io/uhsealevelcenter/idea-oi-kernel`), the `sandbox` container needs
+its own credentials to pull it - and this is **not** the same thing as
+`docker login ghcr.io` on the host: `sandbox_service` runs `msb` (the
+microsandbox CLI/runtime) directly inside its own container
+(`sandbox_service/Dockerfile`), and `msb` pulls OCI images itself,
+independent of the host's Docker daemon and its credential store.
+
+The CLI-documented way to authenticate is `msb registry login`, but that
+stores secrets in an OS credential store (Keychain / Credential Manager /
+Secret Service - see
+[microsandbox's docs](https://docs.microsandbox.dev/cli/image-commands)) -
+none of which exist in the `python:3.11-slim` base this service runs on.
+The documented headless alternative is a `password_env` entry in
+`~/.microsandbox/config.json`, which is what
+`sandbox_service/entrypoint.sh` generates automatically on container start,
+if credentials are supplied:
+
+1. Create a GitHub Personal Access Token (classic) scoped to
+   `read:packages`, with SSO-authorization for `uhsealevelcenter` if the
+   org requires it.
+2. Set `GHCR_USERNAME` (your GitHub username) and `GHCR_PAT` (the token)
+   in the deploy host's `.env`.
+3. Redeploy/restart the `sandbox` service. `entrypoint.sh` writes
+   `/root/.microsandbox/config.json` (on the persistent
+   `idea_microsandbox_data` volume) with:
+   ```json
+   {
+     "registries": {
+       "hosts": {
+         "ghcr.io": {
+           "auth": { "username": "<GHCR_USERNAME>", "password_env": "GHCR_PAT" }
+         }
+       }
+     }
+   }
+   ```
+   `microsandbox` then resolves `GHCR_PAT` from its own process
+   environment (already set via `docker-compose.yml`) at pull time.
+
+Simplest alternative: make the package **public**. It contains no secrets
+(OS packages, this repo's own `daemon.py`/`client.py`) - if there's no
+reason to keep it private, doing so avoids this setup entirely and
+`microsandbox` falls back to an anonymous pull.
+
 ## Why not just use Open Terminal's `/execute` for everything?
 
 Its `/execute` endpoint runs a shell command as a new background process

--- a/sandbox_service/Dockerfile
+++ b/sandbox_service/Dockerfile
@@ -40,9 +40,13 @@ RUN pip install --no-cache-dir -r requirements.txt
 COPY msb_sandbox.py .
 COPY terminal_registry.py .
 COPY main.py .
+COPY entrypoint.sh .
+RUN chmod +x entrypoint.sh
 
 ENV PYTHONUNBUFFERED=1
 
 EXPOSE 8020
 
-CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8020"]
+# See entrypoint.sh - configures microsandbox's registry auth for a private
+# SANDBOX_IMAGE (from GHCR_USERNAME/GHCR_PAT) before starting the app.
+CMD ["./entrypoint.sh"]

--- a/sandbox_service/entrypoint.sh
+++ b/sandbox_service/entrypoint.sh
@@ -1,0 +1,38 @@
+#!/bin/sh
+# Entrypoint for the sandbox_service container - starts the FastAPI app
+# (main.py), but first (optionally) configures microsandbox's registry
+# credentials so it can pull a *private* SANDBOX_IMAGE (see
+# ../interpreter_kernel/README.md's "Private registry auth" section).
+#
+# `msb registry login` (the CLI-documented way to store registry creds -
+# https://docs.microsandbox.dev/cli/image-commands) persists secrets in the
+# OS credential store (Keychain/Credential Manager/Secret Service), none of
+# which exist in this headless python:3.11-slim container. microsandbox's
+# documented headless alternative is a `password_env` entry in
+# ~/.microsandbox/config.json, which is what this generates instead.
+set -eu
+
+if [ -n "${GHCR_PAT:-}" ]; then
+  mkdir -p /root/.microsandbox
+  # /root/.microsandbox is the idea_microsandbox_data volume (see
+  # docker-compose.yml) - this file is small and safe to (re)write on every
+  # container start; it doesn't touch the rest of that volume (msb's own
+  # sandbox/image state).
+  cat > /root/.microsandbox/config.json <<EOF
+{
+  "registries": {
+    "hosts": {
+      "ghcr.io": {
+        "auth": {
+          "username": "${GHCR_USERNAME:-uhsealevelcenter}",
+          "password_env": "GHCR_PAT"
+        }
+      }
+    }
+  }
+}
+EOF
+  echo "Configured microsandbox registry auth for ghcr.io (user: ${GHCR_USERNAME:-uhsealevelcenter})"
+fi
+
+exec uvicorn main:app --host 0.0.0.0 --port 8020


### PR DESCRIPTION
fix build -- added Matthew's openwebUI custom version. Fixed deployment to logout after this has been pulled and built from the uhsealevelcenter registry.

Added necessary fields in env.example for pulling image from registry for pyhon kernel execution and pulling the image iteself in docker-compose file.