### PR TITLE
Split nginx config so HTTPS can be added to prod without touching dev…

### DIFF
--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -49,6 +49,7 @@ services:
       - "0.0.0.0:80:80"
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx-locations.conf:/etc/nginx/snippets/locations.conf:ro
       - ./frontend:/app/frontend:ro,delegated  # Added delegated for better performance
       - ./static:/static:ro  # <--- add this so Nginx sees the same folder
     depends_on:

--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -20,9 +20,11 @@ services:
       # - "443:443"   # uncomment once prod has a real domain + cert
     volumes:
       - ./nginx.conf:/etc/nginx/nginx.conf:ro
+      - ./nginx-locations.conf:/etc/nginx/snippets/locations.conf:ro
       - ./static:/static:ro
       # - ./certbot/conf:/etc/letsencrypt:ro   # cert storage, once TLS is set up
       # - ./certbot/www:/var/www/certbot:ro    # certbot's renewal challenge path
+      # - ./nginx-https-prod.conf:/etc/nginx/https.d/https.conf:ro   # TODO uncomment once nginx-https-prod.conf has a real domain + cert paths filled in
     depends_on:
       - web
       - openwebui

--- a/nginx-https-prod.conf
+++ b/nginx-https-prod.conf
@@ -1,0 +1,18 @@
+# Prod-only HTTPS server block. Mount target: /etc/nginx/https.d/https.conf
+
+# TODO:
+#   1. Replace REPLACE_WITH_DOMAIN below with the real domain.
+#   2. Run Certbot to issue the cert for domain.
+#   3. Uncomment the certbot/conf, certbot/www, and this file's mount line
+#      in docker-compose.prod.yml.
+#   4. Uncomment "443:443" in docker-compose.prod.yml's nginx ports.
+
+server {
+    listen 443 ssl;
+    server_name REPLACE_WITH_DOMAIN;
+
+    ssl_certificate     /etc/letsencrypt/live/REPLACE_WITH_DOMAIN/fullchain.pem;
+    ssl_certificate_key /etc/letsencrypt/live/REPLACE_WITH_DOMAIN/privkey.pem;
+
+    include /etc/nginx/snippets/locations.conf;
+}

--- a/nginx-locations.conf
+++ b/nginx-locations.conf
@@ -1,0 +1,89 @@
+# Shared routing rules, included by both the port-80 and port-443 server
+# blocks in nginx.conf (443 added via nginx-https-prod.conf, prod-only)
+set $backend_upstream http://web:8001;
+set $frontend_upstream http://frontend:8000;
+set $openwebui_upstream http://openwebui:8080;
+
+# Shared conversations - route to backend
+location /share/ {
+    proxy_pass $backend_upstream;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# Open WebUI - replaces the old static frontend entirely.
+location / {
+    proxy_pass $openwebui_upstream;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Open WebUI uses both WebSockets and SSE for streaming chat -
+    # same requirements as the /idea-api/ block below.
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_read_timeout 300s;
+}
+
+# Backend API for conversations (used by share.js)
+location /conversations/ {
+    client_max_body_size 30M;
+    proxy_pass $backend_upstream;
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+}
+
+# Backend API under /idea-api (FastAPI root_path)
+location ^~ /idea-api/ {
+    client_max_body_size 30M;
+    # Bare variable - a trailing path here would truncate the URL.
+    proxy_pass $backend_upstream;
+
+    proxy_set_header Host $host;
+    proxy_set_header X-Real-IP $remote_addr;
+    proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+    proxy_set_header X-Forwarded-Proto $scheme;
+
+    # Timeouts for long-running requests
+    proxy_connect_timeout 300s;
+    proxy_send_timeout 300s;
+    proxy_read_timeout 300s;
+
+    proxy_http_version 1.1;
+    proxy_set_header Upgrade $http_upgrade;
+    proxy_set_header Connection "upgrade";
+
+    proxy_buffering off;
+    proxy_cache off;
+    proxy_set_header Connection '';
+    chunked_transfer_encoding off;
+}
+
+# # Backend API for /sea-api (new Download Conversation API, under development)
+# location /sea-api/ {
+#     client_max_body_size 30M;
+#     proxy_pass http://backend/sea-api/;
+#     proxy_set_header Host $host;
+#     proxy_set_header X-Real-IP $remote_addr;
+#     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+#     proxy_set_header X-Forwarded-Proto $scheme;
+
+#     # WebSocket support
+#     proxy_http_version 1.1;
+#     proxy_set_header Upgrade $http_upgrade;
+#     proxy_set_header Connection "upgrade";
+
+#     # Disable buffering for EventSource (streaming)
+#     proxy_buffering off;
+#     proxy_cache off;
+#     proxy_set_header Connection '';
+#     chunked_transfer_encoding off;
+# }

--- a/nginx.conf
+++ b/nginx.conf
@@ -18,96 +18,18 @@ http {
     # refresh, which is what caused that exact failure mode.
     resolver 127.0.0.11 valid=10s;
 
+    # Prod-only HTTPS block, mounted here by docker-compose.prod.yml; does nothing on dev/staging.
+    include /etc/nginx/https.d/*.conf;
+
     server {
         listen 80;
         server_name localhost 0.0.0.0;
 
-        set $backend_upstream http://web:8001;
-        set $frontend_upstream http://frontend:8000;
-        set $openwebui_upstream http://openwebui:8080;
-
-        # Shared conversations - route to backend
-        location /share/ {
-            proxy_pass $backend_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
+        # Certbot's domain-verification file.
+        location /.well-known/acme-challenge/ {
+            root /var/www/certbot;
         }
 
-        # Open WebUI - replaces the old static frontend entirely.
-        location / {
-            proxy_pass $openwebui_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # Open WebUI uses both WebSockets and SSE for streaming chat -
-            # same requirements as the /idea-api/ block below.
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_read_timeout 300s;
-        }
-
-        # Backend API for conversations (used by share.js)
-        location /conversations/ {
-            client_max_body_size 30M;
-            proxy_pass $backend_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-        }
-
-        # Backend API under /idea-api (FastAPI root_path)
-        location ^~ /idea-api/ {
-            client_max_body_size 30M;
-            # Bare variable - a trailing path here would truncate the URL.
-            proxy_pass $backend_upstream;
-
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # Timeouts for long-running requests
-            proxy_connect_timeout 300s;
-            proxy_send_timeout 300s;
-            proxy_read_timeout 300s;
-
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_set_header Connection '';
-            chunked_transfer_encoding off;
-        }
-
-        # # Backend API for /sea-api (new Download Conversation API, under development)
-        # location /sea-api/ {
-        #     client_max_body_size 30M;
-        #     proxy_pass http://backend/sea-api/;
-        #     proxy_set_header Host $host;
-        #     proxy_set_header X-Real-IP $remote_addr;
-        #     proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-        #     proxy_set_header X-Forwarded-Proto $scheme;
-
-        #     # WebSocket support
-        #     proxy_http_version 1.1;
-        #     proxy_set_header Upgrade $http_upgrade;
-        #     proxy_set_header Connection "upgrade";
-
-        #     # Disable buffering for EventSource (streaming)
-        #     proxy_buffering off;
-        #     proxy_cache off;
-        #     proxy_set_header Connection '';
-        #     chunked_transfer_encoding off;
-        # }
+        include /etc/nginx/snippets/locations.conf;
     }
 }


### PR DESCRIPTION
…/staging

Moved routing rules into a shared file both the existing (port 80) and future (port 443) server blocks can use

Added a prod-only slot for the  HTTPS block once a domain and certificate exist