### PR TITLE
Gets all chat Histroy, instead of only last 10 messages

### DIFF
--- a/langgraph/multi_agent.py
+++ b/langgraph/multi_agent.py
@@ -100,16 +100,7 @@ class ConversationOrchestrator:
         
         # Include relevant conversation history (last N messages for context)
         # TODO: Smart context selection (not all history, just relevant parts)
-        
-        # max_history_messages = 10
-        # recent_history = self.conversation_history#[-max_history_messages:]
-        
-        # if recent_history:
-        #     context_parts.append("\nRecent conversation context:")
-        #     for msg in recent_history:
-        #         role = msg['role'].upper()
-        #         content = msg['content']
-        #         context_parts.append(f"{role}: {content}")
+
         history_messages = [
             msg for msg in self.conversation_history
             if msg.get("type") == "message" and isinstance(msg.get("content"), str)

--- a/langgraph/multi_agent.py
+++ b/langgraph/multi_agent.py
@@ -100,19 +100,32 @@ class ConversationOrchestrator:
         
         # Include relevant conversation history (last N messages for context)
         # TODO: Smart context selection (not all history, just relevant parts)
-        max_history_messages = 10
-        recent_history = self.conversation_history[-max_history_messages:]
         
-        if recent_history:
-            context_parts.append("\nRecent conversation context:")
-            for msg in recent_history:
-                role = msg['role'].upper()
-                content = msg['content']
+        # max_history_messages = 10
+        # recent_history = self.conversation_history#[-max_history_messages:]
+        
+        # if recent_history:
+        #     context_parts.append("\nRecent conversation context:")
+        #     for msg in recent_history:
+        #         role = msg['role'].upper()
+        #         content = msg['content']
+        #         context_parts.append(f"{role}: {content}")
+        history_messages = [
+            msg for msg in self.conversation_history
+            if msg.get("type") == "message" and isinstance(msg.get("content"), str)
+        ]
+
+        if history_messages:
+            context_parts.append("\nConversation history:")
+            for msg in history_messages:
+                role = msg["role"].upper()
+                content = msg["content"]
                 context_parts.append(f"{role}: {content}")
         
         # Current task
         context_parts.append(f"\nCurrent task:\n{user_message}")
-        
+
+
         return "\n".join(context_parts)
     
     def chat(


### PR DESCRIPTION
Test trials:

Original code: Would only get the last ~10 messages. sometimes seemed to be less than 10, but it was working at limiting the amount of messages retrieved. (code currently commented out incase of needing to be reimplemented) The model also seemed to know that it had a 10 message limit cap.

Updated code: Through a few rounds of testing seems to be capable of "remembering" all parts of the chat, further than ~10 messages. When gone past the 10 message point and further, the bot seemed to be capable of remembering the first messages and all information talked about. It was capable of recalling and talking about all conversation topics.  The model also seemed to know that it did not have a memory cap. 