### PR TITLE
Register Microsandbox image publication workflow

### DIFF
--- a/.github/workflows/microsandbox-image.yml
+++ b/.github/workflows/microsandbox-image.yml
@@ -1,0 +1,84 @@
+name: Microsandbox image
+
+on:
+  workflow_dispatch:
+    inputs:
+      publish:
+        description: "Publish only after a local build and smoke test have passed"
+        required: true
+        default: false
+        type: boolean
+      version:
+        description: "Immutable release version, for example 2026.08.10-1"
+        required: false
+        type: string
+
+concurrency:
+  group: microsandbox-image-${{ github.ref }}
+  cancel-in-progress: false
+
+permissions:
+  contents: read
+
+jobs:
+  local-architecture-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    steps:
+      - uses: actions/checkout@v6
+      - name: Build and smoke-test without publishing
+        run: ./interpreter_kernel/test_image.sh idea/oi-kernel:ci
+
+  publish:
+    if: >-
+      github.event_name == 'workflow_dispatch' &&
+      inputs.publish == true &&
+      inputs.version != ''
+    needs: local-architecture-test
+    runs-on: ubuntu-latest
+    timeout-minutes: 90
+    environment: microsandbox-image-publish
+    permissions:
+      contents: read
+      packages: write
+      id-token: write
+    steps:
+      - uses: actions/checkout@v6
+      - uses: docker/setup-qemu-action@v4
+      - uses: docker/setup-buildx-action@v4
+      - name: Log in to GHCR
+        uses: docker/login-action@v4
+        with:
+          registry: ghcr.io
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+      - id: image
+        name: Select immutable image tags
+        env:
+          RELEASE_VERSION: ${{ inputs.version }}
+        run: |
+          set -euo pipefail
+          if [[ ! "${RELEASE_VERSION}" =~ ^[0-9A-Za-z][0-9A-Za-z._-]*$ ]]; then
+            echo "Invalid version '${RELEASE_VERSION}'" >&2
+            exit 2
+          fi
+          owner="${GITHUB_REPOSITORY_OWNER,,}"
+          image="ghcr.io/${owner}/idea-oi-kernel"
+          echo "image=${image}" >> "${GITHUB_OUTPUT}"
+          echo "version_tag=${image}:research-${RELEASE_VERSION}" >> "${GITHUB_OUTPUT}"
+          echo "sha_tag=${image}:sha-${GITHUB_SHA}" >> "${GITHUB_OUTPUT}"
+      - name: Build and publish the multi-architecture release
+        run: |
+          docker buildx build \
+            --platform linux/amd64,linux/arm64 \
+            --provenance=true \
+            --sbom=true \
+            --tag "${{ steps.image.outputs.version_tag }}" \
+            --tag "${{ steps.image.outputs.sha_tag }}" \
+            --push \
+            --file interpreter_kernel/Dockerfile \
+            interpreter_kernel
+      - name: Record the published digest
+        run: |
+          docker buildx imagetools inspect \
+            "${{ steps.image.outputs.version_tag }}"


### PR DESCRIPTION
Adds only the existing Microsandbox image workflow from next-dev to the default branch so GitHub registers its workflow_dispatch endpoint. This does not merge IDEA-next application code into dev. Publishing still requires an explicit publish=true input, an immutable version, a selected source ref, and approval through the microsandbox-image-publish environment.