### PR TITLE
Add self-hosted Langfuse LLM observability

### DIFF
--- a/README.md
+++ b/README.md
@@ -116,6 +116,13 @@ WEBUI_SECRET_KEY=change_this
 # LiteLLM proxy (DB: openssl rand -hex 20; master: printf 'sk-'; openssl rand -hex 32)
 LITELLM_DB_PASSWORD=change_this
 LITELLM_MASTER_KEY=change_this
+
+# Langfuse LLM observability (DB: openssl rand -hex 20; the other three:
+# openssl rand -hex 32 each) - see "LLM Observability (Langfuse)" below.
+LANGFUSE_DB_PASSWORD=change_this
+LANGFUSE_NEXTAUTH_SECRET=change_this
+LANGFUSE_SALT=change_this
+LANGFUSE_ENCRYPTION_KEY=change_this
 ```
 
 See `example.env` for the full list of variables and inline comments explaining each one. Several are commented out by default (`PQA_HOME`/`PAPER_DIRECTORY`, `EARTHDATA_USERNAME`/`PASSWORD`, `SECRET_KEY`, `FIRST_SUPERUSER`/`PASSWORD`, `SMTP_*`, `GUEST_*`) - these are leftover from the previous `app.py`/`auth.py`-based backend, which no longer exists in this repo; leave them commented out unless something reintroduces a consumer for them.
@@ -124,13 +131,14 @@ IDEA has been tested with several LLM inference providers, including OpenAI (htt
 
 ### 3. Set Up the Service Database Roles
 
-LiteLLM and LangGraph use separate, least-privilege Postgres roles and schemas
-on the shared `db` service. Run both setup scripts once before starting the full
-stack; both are idempotent and safe to re-run:
+LiteLLM, LangGraph, and Langfuse each use a separate, least-privilege Postgres
+role and schema on the shared `db` service. Run all three setup scripts once
+before starting the full stack; all are idempotent and safe to re-run:
 
 ```bash
 ./litellm/setup_litellm_db.sh
 ./langgraph/db/setup_langgraph_db.sh
+./langfuse/setup_langfuse_db.sh
 ```
 
 The LangGraph setup builds its service image and initializes the checkpoint
@@ -223,6 +231,42 @@ See `openwebui/README.md` for full details on both.
 
 - Main app: http://localhost
 
+## LLM Observability (Langfuse)
+
+Every call `litellm` makes - from LangGraph's `TerminalAgent`, PaperQA, and Open
+WebUI's background-task model - is traced to a self-hosted
+[Langfuse](https://langfuse.com/) instance (`langfuse` service), grouped by
+conversation (`session_id`) and end user (`trace_user_id`), matching what
+`LITELLM_END_USER_HEADER` already does for spend tracking. This uses Langfuse
+**v2** (Postgres-only self-host), not the current v3, which additionally
+requires ClickHouse, S3/MinIO, and a dedicated Redis; v2 only receives
+security patches (no new features) per Langfuse's own docs, so revisit this
+choice if that becomes a blocker. See
+`docker-compose.yml`'s `langfuse` service and
+`litellm/litellm_config.yaml`'s `success_callback`/`failure_callback` for the
+wiring.
+
+1. Generate the four Langfuse secrets shown in step 2 above and run
+   `./langfuse/setup_langfuse_db.sh` (step 3 above) before first start.
+2. Start (or restart) the stack, then open the Langfuse UI - `:3050` in dev
+   (`docker-compose.override.yml`), otherwise wherever you route it in
+   production (see the Quick Deploy doc) - and create an org/project through
+   the normal sign-up flow. Alternatively, set the `LANGFUSE_INIT_*`
+   variables in `.env` (see `example.env`) to auto-create the org, project,
+   and admin user on first boot without touching the UI - useful for
+   scripted/CI environments.
+3. Under **Project Settings > API Keys**, generate a public/secret key pair
+   and save them into `.env` as `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY`
+   (or, if you used `LANGFUSE_INIT_*`, they already match the project's
+   actual keys - no extra step needed).
+4. Restart `litellm` so it picks up the keys:
+   ```bash
+   docker compose up -d litellm
+   ```
+
+A failure to reach Langfuse only logs a warning inside `litellm` - it never
+blocks or fails the underlying LLM call.
+
 ## Deploying to Production (requires Docker)
 
 ```bash
@@ -231,8 +275,12 @@ docker compose -f docker-compose.yml -f docker-compose.prod.yml up -d --build
 
 Explicit `-f` flags skip `docker-compose.override.yml`, so dev-only host ports (`langgraph`, `sandbox`, `litellm`) and the extra `nginx` service are never published. `docker-compose.prod.yml` is currently an empty overlay kept for this `-f` combo's sake (its one-time purpose - the `sandbox` `/dev/kvm` passthrough - now lives directly in `docker-compose.yml`, gated behind the `KVM_DEVICE_PATH` env var).
 
-Repeat both database setup scripts (step 3 above) and the one-time Open WebUI
-Function setup (step 5 above) on first deploy.
+Repeat all three database setup scripts (step 3 above) and the one-time Open
+WebUI Function setup (step 5 above) on first deploy. The `langfuse` service
+itself is not published to the host by the base `docker-compose.yml` (same as
+`langgraph`/`sandbox`/`litellm`) - route it through your reverse proxy only if
+you want production UI access to traces; `litellm` reaching it over the
+internal compose network is all that's required for tracing to work.
 
 In CI, this is what the `deploy` job in `.github/workflows/deploy.yml` runs remotely over SSH via each environment's `DEPLOY_CMD` GitHub Actions variable.
 
@@ -269,6 +317,7 @@ What this means in practice for local dev:
 ├── sandbox_service/               # Per-user microsandbox microVM execution service
 ├── interpreter_kernel/            # OCI image booted per microVM: Open Terminal + persistent Python kernel
 ├── litellm/                       # LiteLLM proxy config, Dockerfile, and DB setup script
+├── langfuse/                      # Langfuse (LLM observability) DB setup script
 ├── assistants/                    # Official Assistant prompts, logos, manifest, and deployment script
 └── openwebui/                     # Open WebUI Pipe function (idea_pipe.py) wiring the chat frontend to langgraph
     ├── functions/idea_pipe.py     # The Pipe function itself

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -64,5 +64,13 @@ services:
     ports:
       - "8030:8080"
 
+  langfuse:
+    # Dev-only direct access to the Langfuse UI (traces, and the one-time
+    # project-creation step that yields LANGFUSE_PUBLIC_KEY/SECRET_KEY - see
+    # example.env). Not present in the base docker-compose.yml, matching the
+    # other dev-only port publishes above.
+    ports:
+      - "3050:3000"
+
 volumes:
   redis_data:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -248,6 +248,12 @@ services:
       # section and litellm/init_litellm_db.sql for how the `litellm`
       # role/schema this points at get created.
       - LITELLM_DATABASE_URL=postgresql://litellm:${LITELLM_DB_PASSWORD}@db:${POSTGRES_PORT}/${POSTGRES_DB}?schema=litellm
+      # Consumed by litellm_config.yaml's success_callback/failure_callback
+      # (["langfuse"]) below - LANGFUSE_PUBLIC_KEY/LANGFUSE_SECRET_KEY are
+      # NOT re-declared here for the same reason OPENAI_API_KEY isn't above -
+      # env_file already injects them literally from .env once generated
+      # through the `langfuse` service's own UI (see example.env).
+      - LANGFUSE_HOST=http://langfuse:3000
     volumes:
       # Lets the config be edited without rebuilding the image.
       - ./litellm/litellm_config.yaml:/app/litellm_config.yaml:ro
@@ -256,6 +262,60 @@ services:
         condition: service_healthy
       redis:
         condition: service_started
+      # Only needs to be reachable, not necessarily healthy first - a
+      # transient Langfuse outage should log a callback warning, not block
+      # LLM traffic (see litellm_config.yaml's comment on success_callback).
+      langfuse:
+        condition: service_started
+
+  # Self-hosted LLM observability - every call litellm makes (from
+  # langgraph's TerminalAgent, PaperQA, and Open WebUI's background-task
+  # model - see litellm/litellm_config.yaml's success/failure_callback) is
+  # sent here as a trace, grouped by session_id/trace_user_id set in
+  # agents/terminal_agent.py's extra_body["metadata"]. Uses Langfuse v2
+  # (Postgres-only self-host: https://langfuse.com/self-hosting/v2/docker-compose)
+  # rather than the current v3, which additionally requires ClickHouse + S3/
+  # MinIO + a dedicated Redis - v2 only receives security patches (no new
+  # features) per Langfuse's own docs, so revisit if that becomes a
+  # blocker. Reuses the existing `db` Postgres via a dedicated role/schema,
+  # the same pattern as `litellm` below - see langfuse/init_langfuse_db.sql,
+  # which must be run once (idempotent, safe to re-run) before this service
+  # can start successfully.
+  langfuse:
+    # Pinned to the v2 major tag (not a digest, unlike most other images in
+    # this file) - Langfuse's own docs recommend tracking `:2` and running
+    # `docker compose pull langfuse` periodically for patches instead.
+    image: langfuse/langfuse:2
+    container_name: idea_langfuse
+    restart: unless-stopped
+    # No host port here either - dev-only exposure lives in
+    # docker-compose.override.yml, matching langgraph/sandbox/litellm above.
+    env_file:
+      - .env
+    environment:
+      - DATABASE_URL=postgresql://langfuse:${LANGFUSE_DB_PASSWORD?Variable not set}@db:${POSTGRES_PORT:-5432}/${POSTGRES_DB}?schema=langfuse
+      - NEXTAUTH_URL=${LANGFUSE_NEXTAUTH_URL:-http://localhost:3050}
+      - NEXTAUTH_SECRET=${LANGFUSE_NEXTAUTH_SECRET?Variable not set}
+      - SALT=${LANGFUSE_SALT?Variable not set}
+      - ENCRYPTION_KEY=${LANGFUSE_ENCRYPTION_KEY?Variable not set}
+      - TELEMETRY_ENABLED=false
+      # LANGFUSE_INIT_* one-shot bootstrap of an org/project/user on first
+      # boot - see example.env's Langfuse section for the recommended flow
+      # (create the project through the UI once, then paste the generated
+      # keys back into .env for litellm to use, same as LITELLM_VIRTUAL_KEY
+      # below).
+      - LANGFUSE_INIT_ORG_ID=${LANGFUSE_INIT_ORG_ID:-}
+      - LANGFUSE_INIT_ORG_NAME=${LANGFUSE_INIT_ORG_NAME:-}
+      - LANGFUSE_INIT_PROJECT_ID=${LANGFUSE_INIT_PROJECT_ID:-}
+      - LANGFUSE_INIT_PROJECT_NAME=${LANGFUSE_INIT_PROJECT_NAME:-}
+      - LANGFUSE_INIT_PROJECT_PUBLIC_KEY=${LANGFUSE_PUBLIC_KEY:-}
+      - LANGFUSE_INIT_PROJECT_SECRET_KEY=${LANGFUSE_SECRET_KEY:-}
+      - LANGFUSE_INIT_USER_EMAIL=${LANGFUSE_INIT_USER_EMAIL:-}
+      - LANGFUSE_INIT_USER_NAME=${LANGFUSE_INIT_USER_NAME:-}
+      - LANGFUSE_INIT_USER_PASSWORD=${LANGFUSE_INIT_USER_PASSWORD:-}
+    depends_on:
+      db:
+        condition: service_healthy
 
   # Open WebUI frontend, talking to the existing langgraph service via the
   # Pipe function in ./openwebui/functions/idea_pipe.py. Replaces the old

--- a/docs/Quick-Deploy.md
+++ b/docs/Quick-Deploy.md
@@ -30,19 +30,22 @@ or changing defaults.
    At minimum, set `OPENAI_API_KEY`, `OPENAI_BASE_URL`, the Postgres
    credentials, `WEBUI_SECRET_KEY`, `LITELLM_DB_PASSWORD`,
    `LANGGRAPH_DB_PASSWORD`, `LANGGRAPH_AES_KEY`, `IDEA_IDENTITY_SECRET`,
-   `LITELLM_MASTER_KEY`, `LITELLM_VIRTUAL_KEY`, and
-   `INTERNAL_SERVICE_TOKEN`; set `KVM_DEVICE_PATH=/dev/kvm` on the production
+   `LITELLM_MASTER_KEY`, `LITELLM_VIRTUAL_KEY`,
+   `INTERNAL_SERVICE_TOKEN`, `LANGFUSE_DB_PASSWORD`,
+   `LANGFUSE_NEXTAUTH_SECRET`, `LANGFUSE_SALT`, and
+   `LANGFUSE_ENCRYPTION_KEY`; set `KVM_DEVICE_PATH=/dev/kvm` on the production
    host, keep the default `IDEA_CODEX_ENABLED=true` when the published guest
    image is selected, and review `SANDBOX_BACKEND`, `SANDBOX_IMAGE`, `ENABLE_SIGNUP`,
    `CORS_ORIGINS`, registry credentials, and the model names. Blank dedicated
    Codex endpoint/key values currently reuse the external `OPENAI_*` values.
 
-3. Create the isolated LiteLLM and LangGraph database roles, schemas, and
-   checkpoint tables:
+3. Create the isolated LiteLLM, LangGraph, and Langfuse database roles,
+   schemas, and checkpoint tables:
 
    ```bash
    ./litellm/setup_litellm_db.sh
    ./langgraph/db/setup_langgraph_db.sh
+   ./langfuse/setup_langfuse_db.sh
    ```
 
 4. Seed the shared scientific-data volume before first use, if a legacy data
@@ -98,7 +101,14 @@ or changing defaults.
      ./assistants/deploy_assistants_openwebui.py
    ```
 
-8. In **Admin Panel > Functions > IDEA Agent > Valves**, set
+8. Open the Langfuse UI (internal-only unless routed through your reverse
+   proxy - see the root [`README.md`](../README.md)'s "LLM Observability
+   (Langfuse)" section), create an org/project, and generate an API key pair
+   under **Project Settings > API Keys**. Save them as `LANGFUSE_PUBLIC_KEY`
+   and `LANGFUSE_SECRET_KEY` in `.env` (or set the `LANGFUSE_INIT_*`
+   variables beforehand to skip this manual step entirely).
+
+9. In **Admin Panel > Functions > IDEA Agent > Valves**, set
    `INTERNAL_SERVICE_TOKEN` to the same value used in `.env`, then disable
    public signup if required and restart the services after any `.env`
    changes:

--- a/example.env
+++ b/example.env
@@ -229,3 +229,46 @@ LITELLM_MASTER_KEY=$YOUR_LITELLM_MASTER_KEY_HERE
 #     -H "Content-Type: application/json" \
 #     -d '{"max_budget": 100, "models": ["gpt-5.6-terra", "gpt-5.6-sol", "gpt-5.6-luna", "text-embedding-3-small"], "key_alias": "idea-langgraph-shared"}'
 LITELLM_VIRTUAL_KEY=$YOUR_LITELLM_VIRTUAL_KEY_HERE
+
+# ==== Langfuse (self-hosted, v2 - see langfuse/ and docker-compose.yml's
+# `langfuse` service) ====
+# Dedicated Postgres role, scoped to its own `langfuse` schema on the
+# existing `db` service's database - same pattern as LITELLM_DB_PASSWORD
+# above. Owns every object in the `langfuse` schema; has no privileges
+# anywhere else. Run once (idempotent): ./langfuse/setup_langfuse_db.sh
+# Generate with: openssl rand -hex 20
+LANGFUSE_DB_PASSWORD=$YOUR_LANGFUSE_DB_PASSWORD_HERE
+
+# Langfuse's own NextAuth session secret, password-hash salt, and at-rest
+# encryption key (distinct purposes - all three are required).
+# Generate with: openssl rand -hex 32 (for each of the three)
+LANGFUSE_NEXTAUTH_SECRET=$YOUR_LANGFUSE_NEXTAUTH_SECRET_HERE
+LANGFUSE_SALT=$YOUR_LANGFUSE_SALT_HERE
+LANGFUSE_ENCRYPTION_KEY=$YOUR_LANGFUSE_ENCRYPTION_KEY_HERE
+
+# Public URL the Langfuse UI reports itself as - only matters for the
+# dev-only port publish in docker-compose.override.yml. Leave unset in
+# production until Langfuse is actually routed through nginx.
+# LANGFUSE_NEXTAUTH_URL=http://localhost:3050
+
+# Once the `langfuse` service is up (docker compose up -d langfuse), open
+# http://localhost:3050 (dev; see docker-compose.override.yml), create an
+# org/project through the UI, then generate a public/secret API key pair
+# under Project Settings > API Keys and paste them here. litellm's
+# success_callback/failure_callback (see litellm/litellm_config.yaml) uses
+# these to send every LLM call as a trace - restart litellm after setting.
+LANGFUSE_PUBLIC_KEY=
+LANGFUSE_SECRET_KEY=
+
+# Optional one-shot bootstrap (LANGFUSE_INIT_*) to auto-create the
+# org/project/user and skip the manual UI signup above entirely - see
+# docker-compose.yml's `langfuse` service and
+# https://langfuse.com/self-hosting/v2/deployment-guide for the full list
+# of LANGFUSE_INIT_* variables. Leave all blank to use the manual UI flow.
+# LANGFUSE_INIT_ORG_ID=
+# LANGFUSE_INIT_ORG_NAME=
+# LANGFUSE_INIT_PROJECT_ID=
+# LANGFUSE_INIT_PROJECT_NAME=
+# LANGFUSE_INIT_USER_EMAIL=
+# LANGFUSE_INIT_USER_NAME=
+# LANGFUSE_INIT_USER_PASSWORD=

--- a/langfuse/init_langfuse_db.sql
+++ b/langfuse/init_langfuse_db.sql
@@ -1,0 +1,59 @@
+-- Idempotent setup for Langfuse's dedicated Postgres role and schema on the
+-- existing `db` service's database (see docker-compose.yml). Mirrors
+-- litellm/init_litellm_db.sql exactly - see that file's comments for the
+-- rationale. Safe to re-run (e.g. on every deploy) - only creates/adjusts
+-- what's missing and never drops existing data.
+--
+-- Do NOT run this file directly with `psql -f`; it expects two psql
+-- variables to be supplied on the command line (see
+-- langfuse/setup_langfuse_db.sh, which is the intended entry point):
+--   -v langfuse_password='<value of LANGFUSE_DB_PASSWORD from .env>'
+--   -v dbname='<value of POSTGRES_DB from .env>'
+
+-- 1. Role: create it if missing, otherwise just make sure the password
+--    matches .env (e.g. after a manual rotation).
+--
+-- NOTE: this uses psql's client-side \if/\gset instead of a server-side
+-- DO $$ ... $$ block on purpose - psql does NOT interpolate :'variables'
+-- inside dollar-quoted ($$) strings, so :'langfuse_password' would be sent
+-- to the server literally (and fail) if this were a DO block instead.
+SELECT EXISTS (SELECT 1 FROM pg_roles WHERE rolname = 'langfuse') AS langfuse_role_exists \gset
+\if :langfuse_role_exists
+  ALTER ROLE langfuse WITH LOGIN PASSWORD :'langfuse_password';
+\else
+  CREATE ROLE langfuse WITH LOGIN PASSWORD :'langfuse_password';
+\endif
+
+-- 2. Schema: create it owned by langfuse if missing. If it already exists
+--    (e.g. a prior deploy, or migrated in from elsewhere), leave its
+--    contents alone - only fix ownership below so Langfuse's own Prisma
+--    migrations can ALTER/DROP its own tables going forward.
+CREATE SCHEMA IF NOT EXISTS langfuse AUTHORIZATION langfuse;
+ALTER SCHEMA langfuse OWNER TO langfuse;
+
+GRANT CONNECT ON DATABASE :"dbname" TO langfuse;
+GRANT USAGE, CREATE ON SCHEMA langfuse TO langfuse;
+
+-- 3. Re-own any objects already inside the schema (e.g. left over from a
+--    previous deploy that ran migrations as the Postgres superuser
+--    instead of the langfuse role) so `langfuse` owns everything it needs
+--    to ALTER/DROP during future `prisma migrate`/`db push` runs.
+DO $$
+DECLARE r RECORD;
+BEGIN
+  FOR r IN SELECT tablename FROM pg_tables WHERE schemaname = 'langfuse' LOOP
+    EXECUTE format('ALTER TABLE langfuse.%I OWNER TO langfuse', r.tablename);
+  END LOOP;
+  FOR r IN SELECT sequencename FROM pg_sequences WHERE schemaname = 'langfuse' LOOP
+    EXECUTE format('ALTER SEQUENCE langfuse.%I OWNER TO langfuse', r.sequencename);
+  END LOOP;
+  FOR r IN SELECT viewname FROM pg_views WHERE schemaname = 'langfuse' LOOP
+    EXECUTE format('ALTER VIEW langfuse.%I OWNER TO langfuse', r.viewname);
+  END LOOP;
+END
+$$;
+
+-- 4. Default privileges so tables/sequences created by *future* migrations
+--    (run as the langfuse role itself) don't need this script re-run.
+ALTER DEFAULT PRIVILEGES IN SCHEMA langfuse GRANT ALL PRIVILEGES ON TABLES TO langfuse;
+ALTER DEFAULT PRIVILEGES IN SCHEMA langfuse GRANT ALL PRIVILEGES ON SEQUENCES TO langfuse;

--- a/langfuse/setup_langfuse_db.sh
+++ b/langfuse/setup_langfuse_db.sh
@@ -1,0 +1,57 @@
+#!/bin/bash
+# Idempotently creates/repairs Langfuse's dedicated Postgres role and schema
+# on the existing `db` service (see docker-compose.yml and
+# init_langfuse_db.sql in this folder). Mirrors litellm/setup_litellm_db.sh.
+# Safe to re-run on every deploy.
+#
+# Requires the `db` service to already be reachable (starts it via
+# `docker compose up -d` below if it isn't running yet) and .env to have
+# POSTGRES_USER / POSTGRES_PASSWORD / POSTGRES_DB / LANGFUSE_DB_PASSWORD
+# set (see example.env).
+#
+# Usage: ./langfuse/setup_langfuse_db.sh [db-service-name]
+#   (db-service-name defaults to "db" - the base docker-compose.yml service)
+set -euo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+DB_SERVICE="${1:-db}"
+
+if [ ! -f .env ]; then
+  echo "Error: .env not found in ${REPO_ROOT} (copy example.env and fill it in first)." >&2
+  exit 1
+fi
+
+set -a
+source .env
+set +a
+
+: "${POSTGRES_USER:?POSTGRES_USER not set in .env}"
+: "${POSTGRES_PASSWORD:?POSTGRES_PASSWORD not set in .env}"
+: "${POSTGRES_DB:?POSTGRES_DB not set in .env}"
+: "${LANGFUSE_DB_PASSWORD:?LANGFUSE_DB_PASSWORD not set in .env - generate one with: openssl rand -hex 20}"
+
+echo "==> Ensuring '${DB_SERVICE}' is up..."
+docker compose up -d "${DB_SERVICE}"
+
+echo "==> Waiting for '${DB_SERVICE}' to accept connections..."
+tries=0
+until docker compose exec -T "${DB_SERVICE}" pg_isready -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" >/dev/null 2>&1; do
+  tries=$((tries + 1))
+  if [ "${tries}" -ge 60 ]; then
+    echo "Error: '${DB_SERVICE}' did not become ready after 60s." >&2
+    exit 1
+  fi
+  sleep 1
+done
+
+echo "==> Applying langfuse/init_langfuse_db.sql to database '${POSTGRES_DB}'..."
+docker compose exec -T -e PGPASSWORD="${POSTGRES_PASSWORD}" "${DB_SERVICE}" \
+  psql -U "${POSTGRES_USER}" -d "${POSTGRES_DB}" -v ON_ERROR_STOP=1 \
+  -v langfuse_password="${LANGFUSE_DB_PASSWORD}" \
+  -v dbname="${POSTGRES_DB}" \
+  < langfuse/init_langfuse_db.sql
+
+echo "==> langfuse role + schema ready on '${DB_SERVICE}'."

--- a/langgraph/agents/terminal_agent.py
+++ b/langgraph/agents/terminal_agent.py
@@ -412,6 +412,18 @@ class TerminalAgent:
         }
         if temperature is not None:
             llm_kwargs["temperature"] = temperature
+        # Forwarded through litellm to Langfuse (see
+        # litellm/litellm_config.yaml's success_callback/failure_callback)
+        # so every call groups into a per-conversation trace, itself
+        # attributable to this end user - mirrors LITELLM_END_USER_HEADER
+        # above, just scoped to Langfuse's own trace metadata convention
+        # instead of LiteLLM's spend tracking.
+        extra_body: Dict[str, Any] = {
+            "metadata": {
+                "trace_user_id": end_user_id,
+                "session_id": session_id,
+            },
+        }
         if _supports_prompt_caching(model):
             # GPT-5.6's implicit breakpoint includes the changing latest user
             # or tool message. Route calls from this session together and use
@@ -419,9 +431,8 @@ class TerminalAgent:
             llm_kwargs["model_kwargs"] = {
                 "prompt_cache_key": _prompt_cache_key(model, session_id),
             }
-            llm_kwargs["extra_body"] = {
-                "prompt_cache_options": {"mode": "explicit"},
-            }
+            extra_body["prompt_cache_options"] = {"mode": "explicit"}
+        llm_kwargs["extra_body"] = extra_body
         self.llm = ChatOpenAI(**llm_kwargs).bind_tools(self.all_tools)
     
     def _encode_image_to_base64(self, filepath: str) -> tuple[str, str]:

--- a/litellm/litellm_config.yaml
+++ b/litellm/litellm_config.yaml
@@ -97,6 +97,16 @@ general_settings:
 litellm_settings:
   set_verbose: false # Disable debug logging in production.
   json_logs: true # Structured (JSON) logs.
+  # Send every request/response (langgraph's TerminalAgent, PaperQA, and Open
+  # WebUI's background-task model all route through this proxy - see
+  # docker-compose.yml's `litellm` service) to the self-hosted `langfuse`
+  # service below as a trace. Reads LANGFUSE_PUBLIC_KEY / LANGFUSE_SECRET_KEY
+  # / LANGFUSE_HOST from this process's environment (env_file in
+  # docker-compose.yml) - see example.env's Langfuse section. A failure to
+  # reach Langfuse only logs a warning here; it never blocks or fails the
+  # underlying LLM call.
+  success_callback: ["langfuse"]
+  failure_callback: ["langfuse"]
   # Bound one provider attempt inside the proxy. LangGraph has a separate,
   # longer 180-second outer request ceiling so it can classify/report proxy
   # timeouts and safely retry only before any streamed output.


### PR DESCRIPTION
## What was added

Self-hosted Langfuse (v2, Postgres-only self-host) so every LLM call made through the `litellm` proxy — from LangGraph's `TerminalAgent`, PaperQA, and Open WebUI's background-task model — is traced automatically, grouped by conversation (`session_id`) and end user (`trace_user_id`).

Langfuse v2 was chosen over the current v3 to avoid adding ClickHouse, S3/MinIO, and a dedicated Redis on top of the existing stack — v2 only needs the existing `db` Postgres service (via its own dedicated role/schema, same pattern as `litellm`). v2 only receives security patches (no new features) per Langfuse's own docs; revisit if that becomes a blocker.

### New files
- `langfuse/init_langfuse_db.sql`, `langfuse/setup_langfuse_db.sh` — idempotent dedicated Postgres role/schema setup, mirrors `litellm/init_litellm_db.sql`/`setup_litellm_db.sh`.

### Changed files
- `docker-compose.yml` — new `langfuse` service (`langfuse/langfuse:2`), reusing the existing `db` Postgres; `litellm` now depends on it and gets `LANGFUSE_HOST`.
- `litellm/litellm_config.yaml` — `success_callback`/`failure_callback: ["langfuse"]` so every request/response is sent to Langfuse.
- `langgraph/agents/terminal_agent.py` — every LLM call now sends `extra_body["metadata"] = {trace_user_id, session_id}` through litellm so Langfuse traces group by conversation/user instead of being one flat list.
- `docker-compose.override.yml` — dev-only port `3050:3000` for the Langfuse UI.
- `example.env`, `README.md`, `docs/Quick-Deploy.md` — new Langfuse env vars and setup/deploy steps.

## Steps needed to set up and deploy

1. Generate secrets and add them to `.env` (see `example.env`'s Langfuse section):
   - `LANGFUSE_DB_PASSWORD` (`openssl rand -hex 20`)
   - `LANGFUSE_NEXTAUTH_SECRET`, `LANGFUSE_SALT`, `LANGFUSE_ENCRYPTION_KEY` (`openssl rand -hex 32` each)
2. Run `./langfuse/setup_langfuse_db.sh` once (idempotent) before first start.
3. Start/restart the stack so `langfuse` and `litellm` pick up the new service.
4. Create an org/project in the Langfuse UI (`:3050` in dev; route through your reverse proxy in prod if UI access is wanted) and generate an API key pair under **Project Settings > API Keys**, saved as `LANGFUSE_PUBLIC_KEY`/`LANGFUSE_SECRET_KEY` in `.env` — **or** set the `LANGFUSE_INIT_*` variables in `.env` beforehand to auto-bootstrap the org/project/user and matching keys on first boot, skipping the manual UI step (useful for scripted/CI environments).
5. Restart `litellm` (`docker compose up -d litellm`) so it picks up the keys.

A failure to reach Langfuse only logs a warning inside `litellm` — it never blocks or fails the underlying LLM call.

## Testing performed

Brought up `db`, `redis`, `litellm`, `langfuse` locally, bootstrapped a project via `LANGFUSE_INIT_*`, called `litellm`'s `/v1/chat/completions` with `metadata: {session_id, trace_user_id}` (the same fields `terminal_agent.py` sends), and confirmed via Langfuse's public API that the resulting trace was recorded with correct `sessionId`/`userId`, input/output, cost, and latency.

Full agent-loop testing (via `langgraph`/`openwebui`) was not performed in this pass — this validates the `litellm`↔`langfuse` wiring directly, which is what every real conversation turn also goes through.