### PR TITLE
Fix nginx: remove duplicate location / causing next-dev deploy failures

### DIFF
--- a/nginx.conf
+++ b/nginx.conf
@@ -47,23 +47,6 @@ http {
             add_header X-Content-Type-Options "nosniff" always;
         }
 
-        # Open WebUI - replaces the old static frontend entirely.
-        location / {
-            proxy_pass $openwebui_upstream;
-            proxy_set_header Host $host;
-            proxy_set_header X-Real-IP $remote_addr;
-            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
-            proxy_set_header X-Forwarded-Proto $scheme;
-
-            # Open WebUI uses both WebSockets and SSE for streaming chat.
-            proxy_http_version 1.1;
-            proxy_set_header Upgrade $http_upgrade;
-            proxy_set_header Connection "upgrade";
-            proxy_buffering off;
-            proxy_cache off;
-            proxy_read_timeout 300s;
-        }
-
         # Certbot's domain-verification file.
         location /.well-known/acme-challenge/ {
             root /var/www/certbot;


### PR DESCRIPTION
## Root cause
`nginx.conf` defines `location /` directly **and** also `include`s `nginx-locations.conf` (added by the https-tls split, PR #26), which defines `location /` again. The duplicate location block makes nginx fail to start:

```
nginx: [emerg] duplicate location "/" in /etc/nginx/snippets/locations.conf:17
```

This is what broke the last `next-dev` deploy (run 33117279342) — nginx crash-looped so the health/smoke check couldn't reach port 80.

## Fix
Remove the now-redundant standalone `location /` block from `nginx.conf`; the shared `nginx-locations.conf` already provides the identical route.

## Verification
Ran `nginx -t` locally against the fixed `nginx.conf` + `nginx-locations.conf` mounted exactly as `docker-compose.prod.yml` does — config now passes.