### PR TITLE
Add prod to hourly monitoring

### DIFF
--- a/.github/workflows/monitor.yml
+++ b/.github/workflows/monitor.yml
@@ -14,7 +14,7 @@ jobs:
   check:
     strategy:
       matrix:
-        environment: [dev]
+        environment: [dev, prod]
     runs-on: ubuntu-latest
     environment: ${{ matrix.environment }}
     steps:
@@ -37,7 +37,7 @@ jobs:
         timeout-minutes: 2
         run: |
           set -uo pipefail
-          if curl -fsS --connect-timeout 5 --max-time 10 "http://${{ vars.VM_HOST }}/idea-api/health" > /dev/null 2>&1; then
+          if curl -fsS --connect-timeout 5 --max-time 10 "${{ vars.PUBLIC_BASE_URL || format('http://{0}', vars.VM_HOST) }}/idea-api/health" > /dev/null 2>&1; then
             echo "healthy=true" >> "$GITHUB_OUTPUT"
           else
             echo "healthy=false" >> "$GITHUB_OUTPUT"
@@ -153,5 +153,5 @@ jobs:
       - name: Fail job if this run introduced a new health-check outage
         if: always() && !cancelled() && steps.health.outputs.healthy == 'false' && steps.status.outputs.state != steps.compare.outputs.previous
         run: |
-          echo "::error::Health check failed against http://${{ vars.VM_HOST }}/idea-api/health"
+          echo "::error::Health check failed against ${{ vars.PUBLIC_BASE_URL || format('http://{0}', vars.VM_HOST) }}/idea-api/health"
           exit 1


### PR DESCRIPTION
Add prod env to hourly monitoring. Scheduled workflows only run from default branch. 
If default branch changes, it's monitor file must also include prod or whichever desired envs for monitoring.
This pr would include dev and prod only, simply edit the enviroment matrix to monitor other environments.