### PR TITLE
Promote Microsandbox limits and pending signups to staging

### DIFF
--- a/docker-compose.prod.yml
+++ b/docker-compose.prod.yml
@@ -11,6 +11,14 @@ version: '3.8'
 # details.
 
 services:
+  sandbox:
+    # Per-microVM production defaults for the current 8-CPU, 30-GB RAM,
+    # 250-GB disk hosts. Explicit .env values can still override them.
+    environment:
+      - SANDBOX_CPUS=${SANDBOX_CPUS:-2}
+      - SANDBOX_MEMORY_MB=${SANDBOX_MEMORY_MB:-4096}
+      - SANDBOX_DISK_MB=${SANDBOX_DISK_MB:-10240}
+
   nginx:
     # Pinned by digest (was floating :alpine).
     image: nginx@sha256:1a8724a52d432501548a8d8681bb1554c2d09778f8b9ed0882fc3442549980b7

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -349,6 +349,10 @@ services:
     environment:
       - WEBUI_NAME=Open WebUI # Per license, Open WebUI NAME and LOGO must remain in their original, prominent locations throughout the application and user interface.
       - ENABLE_OLLAMA_API=false
+      # Allow account requests by default, but require an administrator to
+      # approve each new account before it receives normal user access.
+      - ENABLE_SIGNUP=${ENABLE_SIGNUP:-true}
+      - DEFAULT_USER_ROLE=${DEFAULT_USER_ROLE:-pending}
       # IDEA executes Python through its own authenticated, persistent
       # LangGraph sandbox kernel. Open WebUI's native code-block Run button
       # and Code Interpreter use a separate Pyodide/Jupyter environment that

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -168,6 +168,11 @@ services:
       - PYTHONUNBUFFERED=1
       # "auto" | "microsandbox" | "local" - see sandbox_service/terminal_registry.py
       - SANDBOX_BACKEND=${SANDBOX_BACKEND:-auto}
+      # Per-microVM local-development limits. The production overlay raises
+      # these defaults; explicit .env values override either profile.
+      - SANDBOX_CPUS=${SANDBOX_CPUS:-1}
+      - SANDBOX_MEMORY_MB=${SANDBOX_MEMORY_MB:-1024}
+      - SANDBOX_DISK_MB=${SANDBOX_DISK_MB:-4096}
       # OCI image booted for each new microsandbox VM - see msb_sandbox.py.
       # Published build of interpreter_kernel/ (see that directory's
       # README for how it's built/pushed) - gives sandboxes the persistent

--- a/docs/Microsandbox-Limits-Handoff.md
+++ b/docs/Microsandbox-Limits-Handoff.md
@@ -1,0 +1,236 @@
+# Microsandbox Resource Limits Handoff
+
+## Objective and implementation status
+
+Environment-configurable resource limits for each IDEA microsandbox are
+implemented on the `next-dev` branch as described below.
+
+- Preserve today's local-development defaults: 1 vCPU, 1024 MiB RAM, and the
+  microsandbox default 4096 MiB writable OCI upper disk.
+- Configure remote `staging` and `prod` deployments for 2 vCPUs, 4096 MiB RAM,
+  and 10240 MiB writable disk per sandbox.
+- Treat these values as per-sandbox ceilings/allocations. Do not change the
+  resource limits of the surrounding `idea_sandbox` Docker service as a
+  substitute.
+- Do not add GPU access to user microVMs as part of this change. The pinned
+  microsandbox runtime has no supported NVIDIA/CUDA passthrough mechanism.
+
+The remote hosts currently provide 8 CPUs, 30 GB RAM, and 250 GB disk in
+total. `prod` additionally has one quarter of a GPU with 10 GB VRAM.
+
+## Previous behavior
+
+Before this change, `sandbox_service/msb_sandbox.py` read:
+
+```text
+SANDBOX_CPUS       default 1
+SANDBOX_MEMORY_MB  default 1024
+```
+
+Those values were passed as `cpus` and `memory` to `Sandbox.create()`. However,
+`docker-compose.yml` did not forward either variable into the `sandbox`
+container, so putting them only in `.env` had no effect.
+
+There was no IDEA disk-size setting. With the pinned
+`microsandbox==0.6.6`, an OCI sandbox uses a managed sparse ext4 writable
+upper disk whose default virtual size is 4096 MiB. Version 0.6.6 exposes a
+larger upper through:
+
+```python
+from microsandbox import Image
+
+Image.oci(image_reference, upper_size_mib=desired_size_mib)
+```
+
+The installed CLI exposes the equivalent `--oci-upper-size` creation option.
+Do not design this patch against newer `root_disk` APIs without deliberately
+upgrading and fully revalidating microsandbox; v0.6.7 changed that API.
+
+Resource settings apply when a microVM is created. The present reconnect path
+starts an existing sandbox without reconciling its creation-time resources,
+image, or mounts. Merely restarting the `sandbox` service therefore does not
+resize existing user sandboxes.
+
+## Implementation
+
+### 1. Expose all three settings through Compose
+
+The base `sandbox.environment` list in
+`docker-compose.yml`:
+
+```yaml
+- SANDBOX_CPUS=${SANDBOX_CPUS:-1}
+- SANDBOX_MEMORY_MB=${SANDBOX_MEMORY_MB:-1024}
+- SANDBOX_DISK_MB=${SANDBOX_DISK_MB:-4096}
+```
+
+keeps ordinary local deployments on the existing limits without requiring
+`.env` changes. The production Compose overlay replaces those defaults with
+2 vCPUs, 4096 MiB RAM, and 10240 MiB disk. Explicit `.env` values override
+either profile.
+
+The same variables and units are documented in `example.env`. Blank values
+select the active Compose profile defaults:
+
+```dotenv
+SANDBOX_CPUS=
+SANDBOX_MEMORY_MB=
+SANDBOX_DISK_MB=
+```
+
+Remote `.env` files are deployment state and are not committed. The
+production overlay already selects these values, but operators may record
+them explicitly in both staging and production:
+
+```dotenv
+SANDBOX_CPUS=2
+SANDBOX_MEMORY_MB=4096
+SANDBOX_DISK_MB=10240
+```
+
+### 2. Add writable-disk sizing to `MicrosandboxTerminal`
+
+In `sandbox_service/msb_sandbox.py`, the implementation:
+
+1. Adds `DEFAULT_DISK_MB`, read from `SANDBOX_DISK_MB` with a 4096 MiB default.
+2. Adds a `disk_mb` constructor argument and stores it on the terminal.
+3. Imports `Image` alongside `Sandbox` in the lazy microsandbox import.
+4. For creation only, replaces the plain image string with:
+
+   ```python
+   Image.oci(self.image, upper_size_mib=self.disk_mb)
+   ```
+
+5. Continues passing `cpus=self.cpus` and `memory=self.memory`.
+
+Only use `Image.oci` for the configured OCI guest-image path. If support for
+bind-root or disk-image roots is added later, it will need a separate typed
+configuration rather than forcing `upper_size_mib` onto every image source.
+
+Validate configuration during service startup. Reject non-integer or
+non-positive CPU, memory, and disk values with an actionable error. Consider
+explicit conservative upper bounds, but do not invent bounds that conflict
+with a deployment requirement.
+
+### 3. Update validation and tests
+
+Add unit coverage that verifies:
+
+- absent variables retain 1 CPU, 1024 MiB RAM, and 4096 MiB disk;
+- Compose forwards all three variables;
+- configured values reach the `Sandbox.create()` call;
+- its `image` argument is an OCI `ImageSource` with the requested upper size;
+- zero, negative, and malformed values fail clearly;
+- reconnecting to an existing sandbox does not claim that its resources were
+  updated.
+
+`sandbox_service/test_local_image.py` now accepts a disk size and verifies
+inside the guest that `/` has approximately the requested capacity, allowing
+for filesystem metadata/reserved-block differences.
+
+The local unit tests do not import the KVM-only image smoke test:
+
+```bash
+python -m unittest \
+  sandbox_service/test_resource_limits.py \
+  sandbox_service/test_service_concurrency.py \
+  sandbox_service/test_terminal_registry_cancellation.py
+docker compose -f docker-compose.yml -f docker-compose.prod.yml config
+```
+
+Run `sandbox_service/test_local_image.py` separately in the built sandbox
+service environment on a KVM-capable remote host; it requires the
+`microsandbox` package and a working runtime.
+
+## Capacity and admission-control caveat
+
+The proposed per-sandbox limits do not cap the number of simultaneously
+running sandboxes. On an 8-CPU/30-GB host:
+
+- CPU reaches the nominal host total at four fully busy 2-vCPU sandboxes.
+- RAM theoretically fits seven 4-GB sandboxes, but the host, Docker services,
+  image cache, kernel, and filesystem cache need headroom. Do not plan for
+  seven simultaneously memory-saturated guests.
+- Ten-GB upper disks are sparse, so 25 sandboxes do not immediately consume
+  250 GB, but they can collectively grow toward that amount. Host OS, Docker
+  layers, the shared-data volume, databases, logs, and microsandbox image
+  cache also use the same physical disk.
+
+This patch should document the operational concurrency limit and monitoring
+expectation. A separate admission-control change may be needed before usage
+can grow beyond a small developer population. At minimum, alert on host RAM,
+disk free space, and active sandbox count instead of assuming per-sandbox
+limits prevent host exhaustion.
+
+## Rollout and existing sandboxes
+
+1. Merge and deploy the code/Compose changes.
+2. Set the three higher values only in each remote deployment's `.env`.
+3. Recreate the `sandbox` Compose service and verify its environment.
+4. Test one disposable microVM and check `nproc`, memory/cgroup limits, and
+   `df` for the root filesystem.
+5. Decide explicitly how to migrate existing sandboxes.
+
+The existing `interpreter_kernel/refresh_sandboxes.sh` recreates every
+sandbox and permanently deletes its writable filesystem. It may be used only
+for the current developer-only population after explicit agreement. It is not
+an acceptable production-user migration. CPU/RAM live modification is not a
+complete migration solution here: disk growth is a creation-time setting in
+the pinned runtime, and the current IDEA reconnect path does not reconcile
+resource configuration.
+
+Before real-user rollout, implement or rehearse snapshot/restore migration,
+or defer the new limits until sandboxes are naturally replaced. Report which
+sandboxes still use the old limits during a mixed-version transition.
+
+## Production GPU assessment
+
+Do not attempt to expose the production GPU partition through
+`MicrosandboxTerminal` in this implementation.
+
+As of this handoff, microsandbox's GPU-support request remains open and the
+available proposal is for a virtio-gpu/Venus Vulkan device, not NVIDIA CUDA
+compute or transparent access to a 10-GB NVIDIA partition. The pinned 0.6.6
+Python SDK has no GPU/device-passthrough creation parameter. Mounting
+`/dev/nvidia*` into the outer Docker `sandbox` service would not make those
+devices appear inside its nested microVMs.
+
+Practical options are:
+
+1. Leave the GPU unused by IDEA until microsandbox and its libkrun backend
+   support the required compute-device passthrough.
+2. Add a separate, tightly scoped GPU worker service on `prod`, launched with
+   the NVIDIA container runtime. IDEA sandboxes would submit bounded jobs and
+   exchange explicit input/output artifacts through an authenticated service
+   API. This requires its own authorization, queueing, resource/time limits,
+   file validation, observability, and threat model; it must not accept
+   unrestricted host shell commands from an untrusted sandbox.
+3. Run selected user workloads directly in per-job GPU-enabled containers.
+   This gives weaker isolation than the current microVM model and should be a
+   separate architecture/security decision, not an incidental Compose flag.
+
+Because prod has only one quarter-GPU partition, assume it is one exclusive
+10-GB compute device unless the provider explicitly supports further safe
+partitioning. A GPU worker should serialize jobs initially; do not promise
+2-CPU/4-GB/10-GB-per-sandbox GPU access to every concurrent microVM.
+
+## Acceptance criteria
+
+- A default local deployment still creates a 1-vCPU, 1024-MiB sandbox with a
+  roughly 4-GiB writable root.
+- New staging/prod sandboxes receive 2 vCPUs, 4096 MiB RAM, and a roughly
+  10-GiB writable root.
+- The running sandbox container exposes the selected configuration without
+  exposing secrets.
+- Disposable real-microVM tests validate the effective guest limits.
+- Existing-sandbox behavior and migration risks are documented and never
+  silently destructive.
+- No GPU device is exposed to user microVMs, and any future GPU worker is
+  tracked as a separate security-reviewed feature.
+
+## Upstream references
+
+- [Microsandbox v0.6.6 release](https://github.com/superradcompany/microsandbox/releases/tag/v0.6.6)
+- [Microsandbox sandbox CLI resource options](https://github.com/superradcompany/microsandbox/blob/main/docs/cli/sandbox-commands.mdx)
+- [Open GPU-support request](https://github.com/superradcompany/microsandbox/issues/291)
+- [Open virtio-gpu/Venus proposal](https://github.com/superradcompany/microsandbox/pull/1194)

--- a/docs/Quick-Deploy.md
+++ b/docs/Quick-Deploy.md
@@ -110,9 +110,10 @@ or changing defaults.
    variables beforehand to skip this manual step entirely).
 
 9. In **Admin Panel > Functions > IDEA Agent > Valves**, set
-   `INTERNAL_SERVICE_TOKEN` to the same value used in `.env`, then disable
-   public signup if required and restart the services after any `.env`
-   changes:
+   `INTERNAL_SERVICE_TOKEN` to the same value used in `.env`. Signup is
+   enabled by default and new accounts enter the pending approval queue;
+   override `ENABLE_SIGNUP=false` only if required. Restart the services
+   after any `.env` changes:
 
    ```bash
    docker compose -f docker-compose.yml -f docker-compose.prod.yml \

--- a/docs/Quick-Deploy.md
+++ b/docs/Quick-Deploy.md
@@ -35,7 +35,8 @@ or changing defaults.
    `LANGFUSE_NEXTAUTH_SECRET`, `LANGFUSE_SALT`, and
    `LANGFUSE_ENCRYPTION_KEY`; set `KVM_DEVICE_PATH=/dev/kvm` on the production
    host, keep the default `IDEA_CODEX_ENABLED=true` when the published guest
-   image is selected, and review `SANDBOX_BACKEND`, `SANDBOX_IMAGE`, `ENABLE_SIGNUP`,
+   image is selected, and review `SANDBOX_BACKEND`, `SANDBOX_IMAGE`,
+   `SANDBOX_CPUS`, `SANDBOX_MEMORY_MB`, `SANDBOX_DISK_MB`, `ENABLE_SIGNUP`,
    `CORS_ORIGINS`, registry credentials, and the model names. Blank dedicated
    Codex endpoint/key values currently reuse the external `OPENAI_*` values.
 

--- a/example.env
+++ b/example.env
@@ -166,6 +166,14 @@ KVM_DEVICE_PATH=
 # use "microsandbox" when failure to boot isolated microVMs must fail closed.
 SANDBOX_BACKEND=auto
 
+# Optional per-microVM limits. Leave unset to use the Compose profile defaults:
+# local development uses 1 vCPU, 1024 MiB RAM, and 4096 MiB writable disk;
+# docker-compose.prod.yml uses 2 vCPUs, 4096 MiB RAM, and 10240 MiB disk.
+# These settings affect newly created sandboxes, not existing persistent VMs.
+SANDBOX_CPUS=
+SANDBOX_MEMORY_MB=
+SANDBOX_DISK_MB=
+
 # OCI image booted for each new microsandbox VM - see
 # sandbox_service/msb_sandbox.py and interpreter_kernel/README.md. Defaults
 # (docker-compose.yml) to ghcr.io/uhsealevelcenter/idea-oi-kernel:slim,

--- a/example.env
+++ b/example.env
@@ -97,7 +97,10 @@ CORS_ORIGINS=http://localhost:8000,http://127.0.0.1:8000,http://localhost:8001,h
 # ==== Open WebUI (see openwebui/functions/idea_pipe.py) ====
 # Generate with: openssl rand -hex 32
 WEBUI_SECRET_KEY=changethis_webui_secret_key
+# Permit self-service account requests, but place new accounts in the admin
+# approval queue rather than granting normal user access immediately.
 ENABLE_SIGNUP=true
+DEFAULT_USER_ROLE=pending
 # Optional admin API key used by Open WebUI deployment/configuration scripts.
 # Output syncing does not use this shared key: the Pipe forwards the current
 # user's authenticated session so generated files have the correct owner.

--- a/openwebui/README.md
+++ b/openwebui/README.md
@@ -267,11 +267,12 @@ the canonical template.
   ```
   Paste the output as `WEBUI_SECRET_KEY=...` in `.env`.
 
-- **`ENABLE_SIGNUP`** - `true`/`false`, no generation needed. Controls
-  whether Open WebUI's own sign-up page accepts new accounts. Leave `true`
-  for the first deploy (the first account created becomes admin - see
-  "Running it" above), then set to `false` afterward to stop further
-  self-service sign-ups if this instance isn't meant to be open to anyone.
+- **`ENABLE_SIGNUP`** - `true`/`false`, no generation needed. Defaults to
+  `true`, allowing Open WebUI's sign-up page to accept account requests.
+- **`DEFAULT_USER_ROLE`** - defaults to `pending`, placing new accounts in
+  the administrator approval queue rather than granting normal user access.
+  Set `ENABLE_SIGNUP=false` only when an instance should stop accepting new
+  account requests.
 
 - **`OPENWEBUI_BASE_URL`** - no generation needed for the default setup.
   This is `langgraph`'s address for reaching `openwebui` over the Docker

--- a/sandbox_service/msb_sandbox.py
+++ b/sandbox_service/msb_sandbox.py
@@ -30,9 +30,29 @@ from typing import Callable, Optional
 # that function instead since fcntl doesn't exist on non-POSIX platforms.
 _KVM_GET_API_VERSION = 0xAE00
 
+
+def _positive_int_env(name: str, default: int) -> int:
+    """Read a positive integer environment setting with a clear error."""
+    raw_value = os.getenv(name, str(default)).strip()
+    if not raw_value:
+        return default
+    try:
+        value = int(raw_value)
+    except ValueError as exc:
+        raise ValueError(
+            f"{name} must be a positive integer, got {raw_value!r}"
+        ) from exc
+    if value <= 0:
+        raise ValueError(
+            f"{name} must be a positive integer, got {raw_value!r}"
+        )
+    return value
+
+
 DEFAULT_IMAGE = os.getenv("SANDBOX_IMAGE", "python")
-DEFAULT_CPUS = int(os.getenv("SANDBOX_CPUS", "1"))
-DEFAULT_MEMORY_MB = int(os.getenv("SANDBOX_MEMORY_MB", "1024"))
+DEFAULT_CPUS = _positive_int_env("SANDBOX_CPUS", 1)
+DEFAULT_MEMORY_MB = _positive_int_env("SANDBOX_MEMORY_MB", 1024)
+DEFAULT_DISK_MB = _positive_int_env("SANDBOX_DISK_MB", 4096)
 # Optional absolute directory inside the sandbox-service container which is
 # exposed read-only at /app/data in every microVM. docker-compose.yml mounts
 # the administrator-managed idea_shared_data volume here. Leaving it unset
@@ -162,6 +182,7 @@ class MicrosandboxTerminal:
         image: str = DEFAULT_IMAGE,
         cpus: int = DEFAULT_CPUS,
         memory: int = DEFAULT_MEMORY_MB,
+        disk_mb: int = DEFAULT_DISK_MB,
         idle_timeout: Optional[int] = DEFAULT_IDLE_TIMEOUT,
         max_duration: Optional[int] = DEFAULT_MAX_DURATION,
         shared_data_host_path: str = DEFAULT_SHARED_DATA_HOST_PATH,
@@ -170,6 +191,7 @@ class MicrosandboxTerminal:
         self.image = image
         self.cpus = cpus
         self.memory = memory
+        self.disk_mb = disk_mb
         self.idle_timeout = idle_timeout
         self.max_duration = max_duration
         self.shared_data_host_path = shared_data_host_path
@@ -247,7 +269,7 @@ class MicrosandboxTerminal:
             return self._run(coro_factory, timeout=timeout)
 
     def _connect_or_create(self):
-        from microsandbox import Sandbox
+        from microsandbox import Image, Sandbox
         from microsandbox.errors import SandboxNotFoundError
 
         async def _get_sandbox():
@@ -266,7 +288,10 @@ class MicrosandboxTerminal:
 
             if handle is None:
                 create_kwargs = dict(
-                    image=self.image,
+                    image=Image.oci(
+                        self.image,
+                        upper_size_mib=self.disk_mb,
+                    ),
                     cpus=self.cpus,
                     memory=self.memory,
                     detached=True,

--- a/sandbox_service/test_local_image.py
+++ b/sandbox_service/test_local_image.py
@@ -21,7 +21,7 @@ async def ensure_missing(name: str) -> None:
     raise RuntimeError(f"refusing to replace existing sandbox {name!r}")
 
 
-def validate(image: str, name: str) -> None:
+def validate(image: str, name: str, disk_mb: int = 4096) -> None:
     if not re.fullmatch(r"idea-image-smoke-[A-Za-z0-9_-]+", name):
         raise ValueError("test sandbox name must start with 'idea-image-smoke-'")
     asyncio.run(ensure_missing(name))
@@ -34,6 +34,7 @@ def validate(image: str, name: str) -> None:
             image=image,
             cpus=2,
             memory=4096,
+            disk_mb=disk_mb,
             idle_timeout=None,
             max_duration=None,
             shared_data_host_path="",
@@ -49,6 +50,20 @@ def validate(image: str, name: str) -> None:
         )
         if "42" not in json.dumps(payload):
             raise RuntimeError(f"persistent kernel did not return 42: {payload}")
+
+        success, root_size, _ = terminal.run(
+            "df -BM --output=size / | tail -n 1"
+        )
+        match = re.search(r"(\d+)M", root_size)
+        if not success or match is None:
+            raise RuntimeError(f"could not inspect guest root capacity: {root_size}")
+        # ext4 metadata and reserved blocks make the reported filesystem
+        # slightly smaller than the configured sparse upper-disk capacity.
+        if int(match.group(1)) < int(disk_mb * 0.9):
+            raise RuntimeError(
+                f"guest root capacity is smaller than requested: {root_size} "
+                f"for {disk_mb} MiB"
+            )
 
         # Open Terminal is intentionally started lazily by this call because
         # detached microsandbox guests do not execute OCI entrypoints.
@@ -75,8 +90,9 @@ def main() -> None:
     parser = argparse.ArgumentParser()
     parser.add_argument("--image", default="idea/oi-kernel:research-local")
     parser.add_argument("--name", default="idea-image-smoke-local")
+    parser.add_argument("--disk-mb", type=int, default=4096)
     args = parser.parse_args()
-    validate(args.image, args.name)
+    validate(args.image, args.name, args.disk_mb)
 
 
 if __name__ == "__main__":

--- a/sandbox_service/test_resource_limits.py
+++ b/sandbox_service/test_resource_limits.py
@@ -1,0 +1,176 @@
+import asyncio
+import os
+import sys
+import types
+import unittest
+from pathlib import Path
+from unittest.mock import patch
+
+sys.path.insert(0, str(Path(__file__).resolve().parent))
+
+from msb_sandbox import MicrosandboxTerminal, _positive_int_env
+
+
+class ResourceLimitConfigurationTests(unittest.TestCase):
+    def test_positive_integer_environment_setting(self):
+        with patch.dict(os.environ, {"SANDBOX_TEST_LIMIT": "2048"}):
+            self.assertEqual(
+                _positive_int_env("SANDBOX_TEST_LIMIT", 1),
+                2048,
+            )
+
+    def test_positive_integer_environment_setting_uses_default(self):
+        for environment in ({}, {"SANDBOX_TEST_LIMIT": ""}):
+            with self.subTest(environment=environment):
+                with patch.dict(os.environ, environment, clear=True):
+                    self.assertEqual(
+                        _positive_int_env("SANDBOX_TEST_LIMIT", 4096),
+                        4096,
+                    )
+
+    def test_invalid_resource_settings_fail_clearly(self):
+        for raw_value in ("0", "-1", "not-a-number"):
+            with self.subTest(raw_value=raw_value):
+                with patch.dict(
+                    os.environ,
+                    {"SANDBOX_TEST_LIMIT": raw_value},
+                ):
+                    with self.assertRaisesRegex(
+                        ValueError,
+                        "SANDBOX_TEST_LIMIT must be a positive integer",
+                    ):
+                        _positive_int_env("SANDBOX_TEST_LIMIT", 1)
+
+    def test_new_sandbox_receives_cpu_memory_and_disk_limits(self):
+        calls = []
+
+        class SandboxNotFoundError(Exception):
+            pass
+
+        class FakeImage:
+            @staticmethod
+            def oci(reference, *, upper_size_mib):
+                return {
+                    "reference": reference,
+                    "upper_size_mib": upper_size_mib,
+                }
+
+        class FakeSandbox:
+            @staticmethod
+            async def get(_name):
+                raise SandboxNotFoundError
+
+            @staticmethod
+            async def create(name, **kwargs):
+                calls.append((name, kwargs))
+                return "sandbox-handle"
+
+        microsandbox = types.ModuleType("microsandbox")
+        microsandbox.Image = FakeImage
+        microsandbox.Sandbox = FakeSandbox
+        errors = types.ModuleType("microsandbox.errors")
+        errors.SandboxNotFoundError = SandboxNotFoundError
+
+        terminal = MicrosandboxTerminal.__new__(MicrosandboxTerminal)
+        terminal.session_id = "resource-test"
+        terminal.image = "registry.example/idea:immutable"
+        terminal.cpus = 2
+        terminal.memory = 4096
+        terminal.disk_mb = 10240
+        terminal.idle_timeout = 1800
+        terminal.max_duration = None
+        terminal.shared_data_host_path = ""
+        terminal._run = lambda factory: asyncio.run(factory())
+
+        with patch.dict(
+            sys.modules,
+            {
+                "microsandbox": microsandbox,
+                "microsandbox.errors": errors,
+            },
+        ):
+            terminal._connect_or_create()
+
+        self.assertEqual(terminal._sandbox, "sandbox-handle")
+        self.assertEqual(len(calls), 1)
+        name, kwargs = calls[0]
+        self.assertEqual(name, "resource-test")
+        self.assertEqual(kwargs["cpus"], 2)
+        self.assertEqual(kwargs["memory"], 4096)
+        self.assertEqual(
+            kwargs["image"],
+            {
+                "reference": "registry.example/idea:immutable",
+                "upper_size_mib": 10240,
+            },
+        )
+
+    def test_existing_sandbox_is_reconnected_without_reprovisioning(self):
+        class SandboxNotFoundError(Exception):
+            pass
+
+        class ExistingSandbox:
+            status = "running"
+
+            async def refresh(self):
+                return None
+
+            async def connect(self):
+                return "existing-sandbox-handle"
+
+        class FakeImage:
+            @staticmethod
+            def oci(*_args, **_kwargs):
+                raise AssertionError("existing sandbox must not rebuild its disk")
+
+        class FakeSandbox:
+            @staticmethod
+            async def get(_name):
+                return ExistingSandbox()
+
+            @staticmethod
+            async def create(*_args, **_kwargs):
+                raise AssertionError("existing sandbox must not be recreated")
+
+        microsandbox = types.ModuleType("microsandbox")
+        microsandbox.Image = FakeImage
+        microsandbox.Sandbox = FakeSandbox
+        errors = types.ModuleType("microsandbox.errors")
+        errors.SandboxNotFoundError = SandboxNotFoundError
+
+        terminal = MicrosandboxTerminal.__new__(MicrosandboxTerminal)
+        terminal.session_id = "existing-resource-test"
+        terminal._run = lambda factory: asyncio.run(factory())
+
+        with patch.dict(
+            sys.modules,
+            {
+                "microsandbox": microsandbox,
+                "microsandbox.errors": errors,
+            },
+        ):
+            terminal._connect_or_create()
+
+        self.assertEqual(terminal._sandbox, "existing-sandbox-handle")
+
+    def test_compose_profiles_define_expected_defaults(self):
+        repository = Path(__file__).resolve().parents[1]
+        base = (repository / "docker-compose.yml").read_text()
+        production = (repository / "docker-compose.prod.yml").read_text()
+
+        for setting in (
+            "SANDBOX_CPUS=${SANDBOX_CPUS:-1}",
+            "SANDBOX_MEMORY_MB=${SANDBOX_MEMORY_MB:-1024}",
+            "SANDBOX_DISK_MB=${SANDBOX_DISK_MB:-4096}",
+        ):
+            self.assertIn(setting, base)
+        for setting in (
+            "SANDBOX_CPUS=${SANDBOX_CPUS:-2}",
+            "SANDBOX_MEMORY_MB=${SANDBOX_MEMORY_MB:-4096}",
+            "SANDBOX_DISK_MB=${SANDBOX_DISK_MB:-10240}",
+        ):
+            self.assertIn(setting, production)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
## Summary

- keep local Microsandboxes at 1 CPU, 1 GiB RAM, and 4 GiB writable disk
- default production-style deployments to 2 CPUs, 4 GiB RAM, and 10 GiB writable disk per new sandbox
- enable OpenWebUI signup by default with new accounts assigned the pending role
- add resource configuration, recreation-safety, and guest disk validation coverage
- document deployment and migration considerations; GPU work remains deferred

## Validation

- 9 focused sandbox unit tests pass
- local and production Compose profiles resolve to their expected values
- behavior was verified on the next-dev deployment

## Rollout note

Resource limits apply when a Microsandbox is created. Existing sandboxes retain their previous limits unless recreated. The developer refresh script is destructive and must not be used where writable workspace state needs to be preserved.